### PR TITLE
README: Add unofficial latex templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ If you're not sure how to contribute, please follow **[this handy tutorial](http
 10. [Department of Computer Science and Technology Twitter](https://twitter.com/HullCompSci).
 11. [University of Hull Hub](https://discord.gg/WsEy47d9j8)
 12. [University of Hull - Hull's digital repository, Hydra](https://hydra.hull.ac.uk/)
+13. [LaTeX Dissertation / Report Templates](https://git.starbeamrainbowlabs.com/Demos/latex-templates) (unofficial edit of an official template)
 
 ## Hull Related <a name="hull"></a>
 1. [For Entrepreneurs Only](https://forentrepreneursonly.co.uk/) - Headquartered on UoH campus providing business mentoring and support.


### PR DESCRIPTION
This is a weird one, 'cause this is actually derived from an official University of Hull template I received from [Nina Dethlefs](https://www.hull.ac.uk/staff-directory/nina-dethlefs) if I recall correctly (which I probably haven't). I've made a number of edits to it to improve it etc, such as changing the font, fixing spacing, etc.

There's also a variant on the official template for a shorter report that doesn't have a dedicated cover page.

I can say for certain that the referencing style used here is 100% correct and official for sure though. I've submitted many formal reports and 2 dissertations using this template / referencing style, and it was fine every single time.